### PR TITLE
Fix pod install Error

### DIFF
--- a/react-native-settings-page/ios/RNSettingsPage.podspec
+++ b/react-native-settings-page/ios/RNSettingsPage.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNSettingsPage
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/Mazurco066/react-native-settings-page"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
- The error is as follows: 
```
[!] The 'RNSettingsPage' pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute 'homepage'.
```
- The error can be reproduced by running `pod install` in the ios directory of a project having react-native-settings-page as an installed package.